### PR TITLE
Fix surface descriptors

### DIFF
--- a/opensubdiv/tmr/subdivisionPlan.cpp
+++ b/opensubdiv/tmr/subdivisionPlan.cpp
@@ -92,8 +92,10 @@ namespace Tmr {
                  + std::min(sharpness, (REAL)level - (REAL)depth));
          }
          return REAL(0);
-     } else
-         static_assert(false, "Invalid single crease dynamic isolation mode");
+     } 
+     
+     static_assert(single_crease_dynamic_isolation == SHARP || 
+         single_crease_dynamic_isolation == SMOOTH, "Invalid single crease dynamic isolation mode");
  }
 
 //

--- a/opensubdiv/tmr/surfaceTableFactory.cpp
+++ b/opensubdiv/tmr/surfaceTableFactory.cpp
@@ -247,7 +247,7 @@ SurfaceTableFactory::Create(TopologyRefiner const& refiner,
             uint8_t edgeAdjacency = computeEdgeAdjacencyBits(level, faceIndex, regFaceSize);
             uint8_t paramRotation = fvlevel && options.depTable ?
                 computeFvarRot(options.depTable->GetDescriptor(surfIndex), startingEdge, regFaceSize) : startingEdge;
-            surfaceTable->descriptors[surfIndex].Set(firstControlPoint, planIndex, paramRotation, topologyMapID);
+            surfaceTable->descriptors[surfIndex].Set(firstControlPoint, planIndex, paramRotation, edgeAdjacency, topologyMapID);
         } else {
             // note: the sub-faces of an irregular face share the same set of control points (the 
             // 'firstControlPoint' offset is the same for all the descriptors)


### PR DESCRIPTION
We got a report that edge adjacency parameter is missing, and as such T-junctions between irregular and regular faces are not being handled correctly. 